### PR TITLE
test(grug-app): probe webhook delivery scope (meow-now)

### DIFF
--- a/.grug-app-probe
+++ b/.grug-app-probe
@@ -1,0 +1,1 @@
+# grug-app probe — deletable


### PR DESCRIPTION
Disposable test PR to verify grug-boss App receives webhooks from `githumps/meow-now`. Will be closed + branch deleted.