### PR TITLE
ci(835): multi-arch build via infra-public (no QEMU)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,75 +1,44 @@
 name: Build and Publish Docker Images
 
+# Multi-arch (amd64+arm64) image build via the #835 container-build-multiarch
+# reusable in the PUBLIC githumps/infra-public repo (meow-now is public →
+# can't call the private infrastructure repo). NATIVE per-arch builds — NO
+# setup-qemu. PR = build-only validation; push main/tag = build + push manifest.
+
 on:
   push:
-    branches:
-      - main
-      - master
-    tags:
-      - 'v*.*.*'
+    branches: [main, master]
+    tags: ['v*.*.*']
   pull_request:
-    branches:
-      - main
-      - master
+    branches: [main, master]
   workflow_dispatch:
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+permissions:
+  contents: read
+  packages: write
 
 jobs:
-  build-and-push:
+  meta:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-
+    outputs:
+      tag: ${{ steps.t.outputs.tag }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - id: t
+        # tag pushes -> the version; everything else -> latest.
+        run: |
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            echo "tag=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+          fi
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GitHub Container Registry
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata for Docker
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=raw,value=latest,enable={{is_default_branch}}
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Generate artifact attestation
-        if: github.event_name != 'pull_request'
-        uses: actions/attest-build-provenance@v1
-        with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          subject-digest: ${{ steps.build.outputs.digest }}
-          push-to-registry: true
+  build:
+    needs: meta
+    uses: githumps/infra-public/.github/workflows/_reusable.container-build-multiarch.yml@c05886465e0de3b288ef356ae260a974cf7c3cff  # infra-public main; bump deliberately
+    with:
+      image: ghcr.io/${{ github.repository }}
+      tag: ${{ needs.meta.outputs.tag }}
+      context: .
+      dockerfile: Dockerfile
+      registry-type: ghcr
+      push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -16,6 +16,7 @@ on:
 permissions:
   contents: read
   packages: write
+  id-token: write
 
 jobs:
   meta:


### PR DESCRIPTION
## Summary

Replaces meow-now's QEMU-emulated multi-arch build with the #835 `container-build-multiarch` reusable in the public `githumps/infra-public` repo (meow-now is public → can't call the private infrastructure repo). Builds amd64 + arm64 on **native runners** (ubuntu-24.04 / ubuntu-24.04-arm) — **no setup-qemu** — pushes each by digest, then merges the manifest list to GHCR. PR runs build-only (both arches, no push); push to main/tag pushes the manifest.

## Test plan

- [ ] This PR's `build (amd64)` + `build (arm64)` jobs build natively (no QEMU) and pass — the multi-arch cross-repo canary
- [ ] merge job skipped on PR (push=false)
- [ ] On push to main: manifest `ghcr.io/githumps/meow-now:latest` assembled from both per-arch digests
- [ ] Reusable ref SHA-pinned to infra-public

## Out of scope

- Restoring the prior metadata-action multi-tag (branch/pr/semver), gha build cache, and build attestation — simplified to latest/version tagging; add back as follow-ups if desired

Part of #835.

Size: M
