### PR TITLE
ci: repoint infra-public reusable pin to re-rooted commit

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -34,7 +34,7 @@ jobs:
 
   build:
     needs: meta
-    uses: githumps/infra-public/.github/workflows/_reusable.container-build-multiarch.yml@d77dce3e0096674024e25c937e63addde7e86401  # infra-public main; bump deliberately
+    uses: githumps/infra-public/.github/workflows/_reusable.container-build-multiarch.yml@41038951557478badb69ca2c34217f75825cfc2e  # infra-public main; bump deliberately
     with:
       image: ghcr.io/${{ github.repository }}
       tag: ${{ needs.meta.outputs.tag }}


### PR DESCRIPTION
## Summary

The shared infra-public reusable-workflow library had its git history re-rooted to purge content that should not have been published. The prior pinned commit no longer exists, so this bumps the reusable pin(s) to the new root commit `4103895`. The reusable logic is byte-identical to what this repo already consumed — only the header comments and the upstream commit history changed.

## Test plan

- [ ] CI resolves the reusable at the new pin (no "workflow file not found" startup failure)
- [ ] PR build-only validation runs both arches via the re-rooted multiarch reusable
- [ ] grep shows no remaining reference to the old infra-public SHAs in `.github/workflows/`

## Out of scope

- Reusable behavior changes — content is identical.
- No image content changes.

Closes #13

Size: XS