### PR TITLE
[meow-now] Add issue-close completeness guard (#947)

### DIFF
--- a/.github/workflows/guard.issue-close-completeness.yml
+++ b/.github/workflows/guard.issue-close-completeness.yml
@@ -1,0 +1,16 @@
+name: Guard · issue-close completeness
+
+# Thin caller of the shared reusable in githumps/infra-public — reopens an issue
+# closed as completed while it still has unchecked acceptance/test boxes. Logic +
+# escape hatches live in the reusable. Public repo → ubuntu-latest (default).
+
+on:
+  issues:
+    types: [closed]
+
+permissions:
+  issues: write
+
+jobs:
+  guard:
+    uses: githumps/infra-public/.github/workflows/check.issue-close-completeness.yml@cd83e5727c0a7b904f780960664a51b3a3a0c685


### PR DESCRIPTION
## Why
Adds the shared issue-close completeness guard to meow-now, the last public repo missing it (#947). Thin caller of `githumps/infra-public/.github/workflows/check.issue-close-completeness.yml` (SHA-pinned `cd83e572`, matching grug/conducted/vroom-vroom/brother-claudius). Public repo, so it runs on ubuntu-latest (runner omitted). Reopens any issue closed-as-completed that still has unchecked acceptance/test checkboxes.

## Acceptance criteria
- [x] Workflow is valid YAML, pins the same reusable SHA as the existing fleet callers
- [x] `permissions: issues: write` granted (the reusable reopens issues)
- [x] Triggers on `issues: closed` only (issues-only, per #947 out-of-scope)
- [ ] Post-merge: close a test issue with an unchecked box -> guard reopens it

Size: XS

## Out of scope
- Enforcing on PRs (issues-only, per #947).

Part of #947.
